### PR TITLE
Add eslint rule for checking copyright header

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,9 @@
       }
     }
   },
+  "plugins": [
+    "header"
+  ],
   "rules": {
     "max-len": [
       "warn",
@@ -49,6 +52,28 @@
           ]
         }
       }
+    ],
+    "header/header": [
+      2,
+      "block", [
+        "*",
+        " * Copyright © 2018 Elastic Path Software Inc. All rights reserved.",
+        " *",
+        " * Licensed under the Apache License, Version 2.0 (the \"License\");",
+        " * you may not use this file except in compliance with the License.",
+        " * You may obtain a copy of the License at",
+        " *",
+        " *     http://www.apache.org/licenses/LICENSE-2.0",
+        " *",
+        " * Unless required by applicable law or agreed to in writing, software",
+        " * distributed under the License is distributed on an \"AS IS\" BASIS,",
+        " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+        " * See the License for the specific language governing permissions and",
+        " * limitations under the License.",
+        " *",
+        " *",
+        " "
+      ]
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4830,6 +4830,12 @@
         "lodash": "^4.15.0"
       }
     },
+    "eslint-plugin-header": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-1.2.0.tgz",
+      "integrity": "sha1-9wR3nG+8fGaPGA2DXeH0YrBGfDc=",
+      "dev": true
+    },
     "eslint-plugin-import": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-config-airbnb": "^17.0.0",
     "eslint-import-resolver-webpack": "^0.10.1",
     "eslint-loader": "^2.0.0",
+    "eslint-plugin-header": "^1.2.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.1.0",
     "eslint-plugin-react": "^7.10.0",


### PR DESCRIPTION
@shaunmaharaj @jatinbehlEP @dusanradovanovic FYI this rule will add linting for making sure our copyright header is in our JS and JSX files. If the header is incorrect or missing the eslint --fix will help to correct it.

I chose to not use regex for the year in the copyright, so that we can easily --fix upon a new year, which will change the copyright in all files. when using regex, the line becomes an [object Object], since the pattern it's matching is an object, and --fix is no longer helpful.