### PR TITLE
Use new root-to-countries relationship

### DIFF
--- a/src/components/addressform.main.jsx
+++ b/src/components/addressform.main.jsx
@@ -26,9 +26,9 @@ const Config = require('Config');
 
 // Array of zoom parameters to pass to Cortex
 const zoomArray = [
-  'element',
-  'element:regions',
-  'element:regions:element',
+  'countries:element',
+  'countries:element:regions',
+  'countries:element:regions:element',
 ];
 
 class AddressFormMain extends React.Component {
@@ -159,7 +159,7 @@ class AddressFormMain extends React.Component {
 
   fetchGeoData() {
     login().then(() => {
-      cortexFetch(`/geographies/${Config.cortexApi.scope}/countries?zoom=${zoomArray.join()}`, {
+      cortexFetch(`/?zoom=${zoomArray.join()}`, {
         headers: {
           'Content-Type': 'application/json',
           Authorization: localStorage.getItem(`${Config.cortexApi.scope}_oAuthToken`),
@@ -168,7 +168,7 @@ class AddressFormMain extends React.Component {
         .then(res => res.json())
         .then((res) => {
           this.setState({
-            geoData: res,
+            geoData: res._countries[0],
           });
         })
         .catch((error) => {

--- a/src/containers/CheckoutPage.jsx
+++ b/src/containers/CheckoutPage.jsx
@@ -223,7 +223,7 @@ class CheckoutPage extends React.Component {
     const { orderData } = this.state;
     const deliveries = orderData._order[0]._deliveries;
     const { messages } = orderData._order[0];
-    const needShipmentDetails = messages.find(message => message.id === 'need.shipment.details');
+    const needShipmentDetails = messages.find(message => message.id === 'need.shipping.address');
     if (needShipmentDetails || deliveries) {
       return (
         <div data-region="shippingAddressesRegion" style={{ display: 'block' }}>


### PR DESCRIPTION
entrypoint was being formed for countries, but with the new change in ep-commerce for root-to-countries relationship it can now be followed from '/' with a zoom instead. changing the implementation to be consistent with the rest of cortex calls.
also fixed a small bug change in CheckoutPage since the needinfo message.id has changed in 7.3